### PR TITLE
[PR] Explicitly set the `post_status` parameter for the scholarship query

### DIFF
--- a/includes/scholarship-shortcodes.php
+++ b/includes/scholarship-shortcodes.php
@@ -332,6 +332,7 @@ function ajax_callback() {
 	$scholarships_query_args = array(
 		'orderby' => 'title',
 		'order' => 'ASC',
+		'post_status' => 'publish',
 		'posts_per_page' => -1,
 		'post_type' => \WSU\Scholarships\Post_Type\post_type_slug(),
 		'meta_query' => array(


### PR DESCRIPTION
Currently, scholarship posts with a status of `draft` are showing up.